### PR TITLE
Add licence date and owner.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2019 Google
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The project licence file was missing the copyright date and owner. Added today / Google.