### PR TITLE
Fixed crash from issue #13 in Settings

### DIFF
--- a/LeanbackShowcase/app/src/main/java/androidx/leanback/leanbackshowcase/app/settings/SettingsExampleFragment.java
+++ b/LeanbackShowcase/app/src/main/java/androidx/leanback/leanbackshowcase/app/settings/SettingsExampleFragment.java
@@ -14,24 +14,18 @@
 
 package androidx.leanback.leanbackshowcase.app.settings;
 
-import android.app.Fragment;
-import android.content.Context;
 import android.os.Bundle;
 import androidx.preference.PreferenceFragment;
 import androidx.leanback.leanbackshowcase.R;
 import androidx.leanback.preference.LeanbackPreferenceFragment;
 import androidx.leanback.preference.LeanbackSettingsFragment;
-import androidx.preference.DialogPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceScreen;
 import android.widget.Toast;
 
 import java.util.Arrays;
-import java.util.Stack;
 
-public class SettingsExampleFragment extends LeanbackSettingsFragment implements DialogPreference.TargetFragment {
-
-    private final Stack<Fragment> fragments = new Stack<Fragment>();
+public class SettingsExampleFragment extends LeanbackSettingsFragment {
 
     @Override
     public void onPreferenceStartInitialScreen() {
@@ -52,11 +46,6 @@ public class SettingsExampleFragment extends LeanbackSettingsFragment implements
         return true;
     }
 
-    @Override
-    public Preference findPreference(CharSequence prefKey) {
-        return ((PreferenceFragment) fragments.peek()).findPreference(prefKey);
-    }
-
     private PreferenceFragment buildPreferenceFragment(int preferenceResId, String root) {
         PreferenceFragment fragment = new PrefFragment();
         Bundle args = new Bundle();
@@ -66,7 +55,7 @@ public class SettingsExampleFragment extends LeanbackSettingsFragment implements
         return fragment;
     }
 
-    private class PrefFragment extends LeanbackPreferenceFragment {
+    public static class PrefFragment extends LeanbackPreferenceFragment {
 
         @Override
         public void onCreatePreferences(Bundle bundle, String s) {
@@ -91,16 +80,5 @@ public class SettingsExampleFragment extends LeanbackSettingsFragment implements
             return super.onPreferenceTreeClick(preference);
         }
 
-        @Override
-        public void onAttach(Context context) {
-            fragments.push(this);
-            super.onAttach(context);
-        }
-
-        @Override
-        public void onDetach() {
-            fragments.pop();
-            super.onDetach();
-        }
     }
 }

--- a/LeanbackShowcase/app/src/main/res/xml/prefs.xml
+++ b/LeanbackShowcase/app/src/main/res/xml/prefs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
                   xmlns:app="http://schemas.android.com/apk/res-auto"
-                  android:summary="This is a dummy activitiy only to show case how to build a settings in an application. Changing configurations in this example doesn't affect anything."
+                  android:summary="This is a dummy activity only to show case how to build a settings in an application. Changing configurations in this example doesn't affect anything."
                   android:title="Settings Example">
     <PreferenceScreen
         android:icon="@drawable/ic_settings_wifi_4_bar"


### PR DESCRIPTION
All Fragments need to have a public default constructor, so that they
can be recreated by the system. In addition, they must be static if they
are inner classes because there will be no reference to the parent when
recreated.

I removed the Stack of Fragments that was being kept because this is
also a risky behavior as it's easy to keep references that should be
garbage collected. Fortunately, this sample doesn't need to retain these
Fragments to demo basic TV app settings.