### PR TITLE
Handle media actions for captions and ratings through MediaSessionConnector

### DIFF
--- a/ClassicsKotlin/app/build.gradle
+++ b/ClassicsKotlin/app/build.gradle
@@ -73,42 +73,42 @@ dependencies {
 
     // Kotlin lang
     def coroutines_version = "1.1.0"
-    implementation 'androidx.core:core-ktx:1.1.0'
+    implementation 'androidx.core:core-ktx:1.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
     // App compat and UI things
+    implementation "androidx.media:media:1.1.0"
     implementation 'androidx.leanback:leanback:1.0.0'
     implementation 'androidx.palette:palette-ktx:1.0.0'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0-alpha05'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
     // TV provider support library
     implementation 'androidx.tvprovider:tvprovider:1.0.0'
 
     // JSON parsing
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.6'
 
     // Navigation library
-    def nav_version = '2.1.0'
+    def nav_version = '2.2.1'
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // Room library
-    def room_version = "2.2.0"
+    def room_version = "2.2.4"
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
 
     // Work library
-    def work_version = "2.2.0"
+    def work_version = "2.3.2"
     implementation "androidx.work:work-runtime:$work_version"
     implementation "androidx.work:work-runtime-ktx:$work_version"
 
     // ExoPlayer's leanback extension
-    def exoplayer_version = '2.10.3'
+    def exoplayer_version = '2.11.3'
     implementation "com.google.android.exoplayer:exoplayer-core:$exoplayer_version"
     implementation "com.google.android.exoplayer:exoplayer-ui:$exoplayer_version"
     implementation "com.google.android.exoplayer:extension-mediasession:$exoplayer_version"
@@ -122,7 +122,6 @@ dependencies {
     testImplementation 'androidx.test:rules:1.2.0'
     testImplementation 'androidx.test:runner:1.2.0'
     testImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    testImplementation "org.robolectric:robolectric:4.3"
 
     // Instrumented testing
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/ClassicsKotlin/app/build.gradle
+++ b/ClassicsKotlin/app/build.gradle
@@ -117,9 +117,6 @@ dependencies {
     // Coil
     implementation 'io.coil-kt:coil:0.7.0'
 
-    // Leak canary
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.0-beta-3'
-
     // Unit testing
     testImplementation 'androidx.test.ext:junit:1.1.1'
     testImplementation 'androidx.test:rules:1.2.0'

--- a/ClassicsKotlin/app/src/main/java/com/android/tv/classics/MainActivity.kt
+++ b/ClassicsKotlin/app/src/main/java/com/android/tv/classics/MainActivity.kt
@@ -19,7 +19,6 @@ package com.android.tv.classics
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.os.StrictMode
 import android.util.Log
 import androidx.fragment.app.FragmentActivity
 import androidx.navigation.Navigation
@@ -39,29 +38,16 @@ import java.util.concurrent.TimeUnit
 /** Entry point for the Android TV application */
 class MainActivity : FragmentActivity() {
 
+    companion object {
+        private val TAG = MainActivity::class.java.simpleName
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
         val activity = this
         val db = TvMediaDatabase.getInstance(this)
-
-        // Enable a number of debugging utilities when the app is running a DEBUG build
-        if (BuildConfig.DEBUG) {
-
-            // TODO(owahltinez): https://github.com/googlecodelabs/kotlin-coroutines/issues/23
-            Dispatchers.Main
-
-            // Set strict mode for thread and VM
-            StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.Builder()
-                    .detectAll()
-                    .penaltyLog()
-                    .build())
-            StrictMode.setVmPolicy(StrictMode.VmPolicy.Builder()
-                    .detectAll()
-                    .penaltyLog()
-                    .build())
-        }
 
         // Navigates to other fragments based on Intent's action
         // [MainActivity] is the main entry point for all intent filters
@@ -109,7 +95,4 @@ class MainActivity : FragmentActivity() {
                         .build())
     }
 
-    companion object {
-        private val TAG = MainActivity::class.java.simpleName
-    }
 }

--- a/ClassicsKotlin/app/src/main/java/com/android/tv/classics/models/TvMediaMetadata.kt
+++ b/ClassicsKotlin/app/src/main/java/com/android/tv/classics/models/TvMediaMetadata.kt
@@ -33,6 +33,7 @@ import androidx.room.Update
 import androidx.tvprovider.media.tv.BasePreviewProgram
 import androidx.tvprovider.media.tv.TvContractCompat
 import kotlinx.android.parcel.Parcelize
+import java.util.Locale
 
 /**
  * Data class representing a piece of content metadata (title, content URI, state-related fields
@@ -172,7 +173,7 @@ data class TvMediaMetadata(
     companion object {
         /** Convenience function used to maximize search matches by ignoring punctuation symbols */
         fun searchableText(text: String) =
-                text.replace(Regex("[^A-Za-z0-9 ]"), "")
+                text.replace(Regex("[^A-Za-z0-9 ]"), "").toLowerCase(Locale.getDefault())
     }
 }
 

--- a/ClassicsKotlin/build.gradle
+++ b/ClassicsKotlin/build.gradle
@@ -25,9 +25,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.0.0"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.2.1"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Media actions were not propagating through to ExoPlayer because the MediaSession.Callback was being overridden; the new callbacks for caption and rating actions can now be called through MediaSessionConnector