### PR TITLE
Set content description on cards

### DIFF
--- a/ClassicsKotlin/app/src/main/java/com/android/tv/classics/presenters/TvMediaMetadataPresenter.kt
+++ b/ClassicsKotlin/app/src/main/java/com/android/tv/classics/presenters/TvMediaMetadataPresenter.kt
@@ -38,6 +38,7 @@ class TvMediaMetadataPresenter(private val cardHeight: Int = DEFAULT_CARD_HEIGHT
         }
 
         card.titleText = metadata.title
+        card.contentDescription = metadata.title
         card.setMainImageDimensions(cardWidth, cardHeight)
         card.mainImageView.load(metadata.artUri)
     }


### PR DESCRIPTION
Enables Talkback to announce the current title of the selected card.