### PR TITLE
Fixed issue (#59) building the LeanbackShowcase sample

### DIFF
--- a/LeanbackShowcase/app/build.gradle
+++ b/LeanbackShowcase/app/build.gradle
@@ -15,6 +15,8 @@
  */
 
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 28
@@ -23,6 +25,7 @@ android {
         applicationId 'com.example.android.persistence'
         minSdkVersion 21
         targetSdkVersion 28
+        compileSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -38,8 +41,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    dataBinding {
-        enabled = true
+    buildFeatures {
+        dataBinding = true
     }
     productFlavors {
     }
@@ -47,7 +50,6 @@ android {
     lintOptions {
         abortOnError false
     }
-
 }
 
 dependencies {
@@ -59,8 +61,8 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:' + rootProject.supportLibVersion
     implementation 'androidx.lifecycle:lifecycle-extensions:' + rootProject.archLifecycleVersion
     implementation 'androidx.room:room-runtime:' + rootProject.archRoomVersion
-    annotationProcessor "androidx.lifecycle:lifecycle-compiler:" + rootProject.archLifecycleVersion
-    annotationProcessor "androidx.room:room-compiler:" + rootProject.archRoomVersion
+    kapt "androidx.lifecycle:lifecycle-compiler:" + rootProject.archLifecycleVersion
+    kapt "androidx.room:room-compiler:" + rootProject.archRoomVersion
 
     testImplementation 'junit:junit:4.12'
 
@@ -96,7 +98,7 @@ dependencies {
     implementation "com.google.dagger:dagger-android:" + rootProject.daggerVersion
     implementation "com.google.dagger:dagger-android-support:" + rootProject.daggerVersion
 
-    annotationProcessor "com.google.dagger:dagger-android-processor:" + rootProject.daggerVersion
-    annotationProcessor "com.google.dagger:dagger-compiler:" + rootProject.daggerVersion
+    kapt "com.google.dagger:dagger-android-processor:" + rootProject.daggerVersion
+    kapt "com.google.dagger:dagger-compiler:" + rootProject.daggerVersion
 }
 

--- a/LeanbackShowcase/app/src/main/java/androidx/leanback/leanbackshowcase/app/media/MusicPlaybackService.java
+++ b/LeanbackShowcase/app/src/main/java/androidx/leanback/leanbackshowcase/app/media/MusicPlaybackService.java
@@ -78,7 +78,7 @@ public class MusicPlaybackService extends Service {
     private boolean mInitialized = false; // true when the MediaPlayer is prepared/initialized
 
     private static final int FOCUS_CHANGE = 2;
-    private NotificationManager mNotificationManager = (NotificationManager) getApplicationContext().getSystemService(Context.NOTIFICATION_SERVICE);
+    private NotificationManager mNotificationManager;
 
 
     private Handler mMediaPlayerHandler = new Handler() {
@@ -520,7 +520,7 @@ public class MusicPlaybackService extends Service {
     private void createNowPlayingChannel() {
         NotificationChannel channel = new NotificationChannel(NOW_PLAYING_CHANNEL, getString(R.string.now_playing_channel_name), NotificationManager.IMPORTANCE_LOW);
         channel.setDescription(getString(R.string.now_playing_channel_description));
-        mNotificationManager.createNotificationChannel(channel);
+        getNotificationManager().createNotificationChannel(channel);
     }
 
     private Boolean shouldCreateNowPlayingChannel() {
@@ -529,7 +529,14 @@ public class MusicPlaybackService extends Service {
 
     @RequiresApi(api = Build.VERSION_CODES.O)
     private Boolean notificationChannelExists() {
-        return mNotificationManager.getNotificationChannel(NOW_PLAYING_CHANNEL) != null;
+        return getNotificationManager().getNotificationChannel(NOW_PLAYING_CHANNEL) != null;
+    }
+
+    private NotificationManager getNotificationManager() {
+        if (mNotificationManager == null) {
+            mNotificationManager = (NotificationManager) getApplicationContext().getSystemService(Context.NOTIFICATION_SERVICE);
+        }
+        return mNotificationManager;
     }
 
     @Override

--- a/LeanbackShowcase/app/src/main/java/androidx/leanback/leanbackshowcase/app/room/di/androidinject/ActivityBuildersModule.java
+++ b/LeanbackShowcase/app/src/main/java/androidx/leanback/leanbackshowcase/app/room/di/androidinject/ActivityBuildersModule.java
@@ -16,17 +16,15 @@
 
 package androidx.leanback.leanbackshowcase.app.room.di.androidinject;
 
-import android.app.Activity;
 import androidx.leanback.leanbackshowcase.app.room.controller.overview.LiveDataRowsActivity;
 import androidx.leanback.leanbackshowcase.app.room.controller.search.SearchActivity;
 import androidx.leanback.leanbackshowcase.app.room.di.androidinjectorannotation.LiveDataOverviewActivitySubcomponent;
 import androidx.leanback.leanbackshowcase.app.room.di.scope.PerActivity;
-import dagger.Binds;
+
 import dagger.Module;
-import dagger.android.ActivityKey;
 import dagger.android.AndroidInjector;
 import dagger.android.ContributesAndroidInjector;
-import dagger.multibindings.IntoMap;
+import dagger.multibindings.ClassKey;
 
 @Module
 public abstract class ActivityBuildersModule {
@@ -37,8 +35,6 @@ public abstract class ActivityBuildersModule {
             SearchFragmentInjectorInstallmentFactoryBindingModule.class})
     abstract SearchActivity contributeToAndriodInjectorForSearchActivity();
 
-    @Binds
-    @IntoMap
-    @ActivityKey(LiveDataRowsActivity.class)
-    abstract AndroidInjector.Factory<? extends Activity> bindActivityInjectorFactory(LiveDataOverviewActivitySubcomponent.Builder builder);
+    @ClassKey(LiveDataRowsActivity.class)
+    abstract AndroidInjector.Factory<?> bindActivityInjectorFactory(LiveDataOverviewActivitySubcomponent.Builder builder);
 }

--- a/LeanbackShowcase/app/src/main/java/androidx/leanback/leanbackshowcase/app/room/di/androidinjectorannotation/FragmentBuildersModule.java
+++ b/LeanbackShowcase/app/src/main/java/androidx/leanback/leanbackshowcase/app/room/di/androidinjectorannotation/FragmentBuildersModule.java
@@ -17,11 +17,11 @@
 package androidx.leanback.leanbackshowcase.app.room.di.androidinjectorannotation;
 
 import androidx.leanback.leanbackshowcase.app.room.controller.overview.LiveDataFragment;
-import androidx.fragment.app.Fragment;
+
 import dagger.Binds;
 import dagger.Module;
 import dagger.android.AndroidInjector;
-import dagger.android.support.FragmentKey;
+import dagger.multibindings.ClassKey;
 import dagger.multibindings.IntoMap;
 
 @Module(subcomponents = LiveDataOverviewFragmentSubComponent.class)
@@ -29,7 +29,7 @@ public abstract class FragmentBuildersModule {
 
     @Binds
     @IntoMap
-    @FragmentKey(LiveDataFragment.class)
-    abstract AndroidInjector.Factory<? extends Fragment> bindFragmentInjectorFactory(
+    @ClassKey(LiveDataFragment.class)
+    abstract AndroidInjector.Factory<?> bindFragmentInjectorFactory(
             LiveDataOverviewFragmentSubComponent.Builder builder);
 }

--- a/LeanbackShowcase/app/src/main/java/androidx/leanback/leanbackshowcase/app/rows/VideoContent.java
+++ b/LeanbackShowcase/app/src/main/java/androidx/leanback/leanbackshowcase/app/rows/VideoContent.java
@@ -165,7 +165,7 @@ public class VideoContent implements Parcelable {
         mCategory = in.readString();
     }
 
-    /* package */ static final Creator CREATOR = new Creator() {
+    public static final Creator<VideoContent> CREATOR = new Creator<VideoContent>() {
         public VideoContent createFromParcel(Parcel in) {
             return new VideoContent(in);
         }

--- a/LeanbackShowcase/build.gradle
+++ b/LeanbackShowcase/build.gradle
@@ -22,8 +22,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-
+        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -41,9 +41,9 @@ task clean(type: Delete) {
 }
 
 ext {
-    buildToolsVersion = "28.0.3"
+    buildToolsVersion = "30.0.2"
     supportLibVersion = "1.0.0"
-    daggerVersion = "2.15"
+    daggerVersion = "2.21"
     materialVersion="1.0.0"
     testVersion = "1.2.0"
     espressoVersion = "3.1.0"

--- a/LeanbackShowcase/gradle/wrapper/gradle-wrapper.properties
+++ b/LeanbackShowcase/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
An outdated version of Gradle was causing Android Studio to error, so I
updated that to the latest version. With the latest version, Dagger
failed to build. I updated it to 2.21 to fix the issues and updated the
generics usage, but this is far from the latest version. There is a
significant amount of work if we want to update to the latest version
that should be considered separately from this.

This also fixes a crash in MusicPlaybackService from the Application
being referenced before it is available and another crash in playback
due to VideoContent not having an accessible CREATOR.

Note: There is still a crash in the LiveData example due to the dagger
setup, but at least this PR gets everything building and all other
sections working again.