### PR TITLE
Migrate to ExoPlayer 2.17.1

### DIFF
--- a/ReferenceAppKotlin/app/build.gradle
+++ b/ReferenceAppKotlin/app/build.gradle
@@ -26,12 +26,11 @@ apply plugin: "androidx.navigation.safeargs.kotlin"
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 30
-
+    compileSdkVersion 32
     defaultConfig {
         applicationId "com.android.tv.reference"
         minSdkVersion 23
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
 
@@ -76,19 +75,19 @@ dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
     // AndroidX libraries
-    def leanback_version = "1.1.0-rc01"
-    def room_version = "2.2.6"
-    def fragment_version = "1.3.2"
+    def leanback_version = "1.2.0-alpha02"
+    def room_version = "2.4.2"
+    def fragment_version = "1.4.1"
     def cast_tv_version = "17.0.0"
     def cast_version = "19.0.0"
-    implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation "androidx.core:core-ktx:1.3.2"
+    implementation "androidx.appcompat:appcompat:1.4.1"
+    implementation "androidx.core:core-ktx:1.7.0"
     implementation "androidx.fragment:fragment-ktx:$fragment_version"
     implementation "androidx.leanback:leanback:$leanback_version"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
-    implementation "androidx.preference:preference-ktx:1.1.1"
+    implementation "androidx.preference:preference-ktx:1.2.0"
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
@@ -100,7 +99,7 @@ dependencies {
     debugImplementation "androidx.fragment:fragment-testing:$fragment_version"
 
     // Work library used for simplifying work done in the background
-    def work_version = "2.5.0"
+    def work_version = "2.7.1"
     implementation "androidx.work:work-runtime:$work_version"
 
     // TV provider library used for updating home screen channels
@@ -110,38 +109,38 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:2.71828'
 
     // Exoplayer for playback
-    def exoplayer_version = "2.13.3"
+    def exoplayer_version = "2.17.1"
     implementation "com.google.android.exoplayer:exoplayer-core:$exoplayer_version"
     implementation "com.google.android.exoplayer:extension-leanback:$exoplayer_version"
     implementation "com.google.android.exoplayer:extension-mediasession:$exoplayer_version"
 
     // Google Play Services for identity
-    def playservices_version = "19.0.0"
+    def playservices_version = "20.1.0"
     implementation "com.google.android.gms:play-services-auth:$playservices_version"
 
     // Moshi for JSON parsing
-    implementation("com.squareup.moshi:moshi-kotlin:1.9.2")
-    kapt("com.squareup.moshi:moshi-kotlin-codegen:1.9.2")
+    implementation("com.squareup.moshi:moshi-kotlin:1.13.0")
+    kapt("com.squareup.moshi:moshi-kotlin-codegen:1.13.0")
 
     // Retrofit for HTTP requests
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'
 
     // Logging
-    implementation("com.jakewharton.timber:timber:4.7.1")
+    implementation("com.jakewharton.timber:timber:5.0.1")
 
     // Testing libraries
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'android.arch.core:core-testing:1.1.1'
     testImplementation "androidx.room:room-testing:$room_version"
-    testImplementation 'androidx.test:core:1.3.0'
-    testImplementation 'androidx.test:rules:1.3.0'
-    testImplementation 'androidx.test:runner:1.3.0'
-    testImplementation 'androidx.test.ext:junit:1.1.2'
+    testImplementation 'androidx.test:core:1.4.0'
+    testImplementation 'androidx.test:rules:1.4.0'
+    testImplementation 'androidx.test:runner:1.4.0'
+    testImplementation 'androidx.test.ext:junit:1.1.3'
     testImplementation "androidx.work:work-testing:$work_version"
-    testImplementation "com.google.truth:truth:1.0.1"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2"
-    testImplementation "org.mockito:mockito-core:3.3.3"
-    testImplementation 'org.mockito:mockito-inline:2.13.0'
-    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation "com.google.truth:truth:1.1.3"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0-native-mt"
+    testImplementation "org.mockito:mockito-core:4.4.0"
+    testImplementation 'org.mockito:mockito-inline:4.4.0'
+    testImplementation 'org.robolectric:robolectric:4.7.3'
 }

--- a/ReferenceAppKotlin/app/src/main/AndroidManifest.xml
+++ b/ReferenceAppKotlin/app/src/main/AndroidManifest.xml
@@ -46,6 +46,7 @@
 
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:configChanges="keyboard|keyboardHidden|navigation">
 
             <!-- Used as the main entry point from the leanback launcher -->

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/MainActivity.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/MainActivity.kt
@@ -111,10 +111,10 @@ class MainActivity : FragmentActivity() {
         @Suppress("ConstantConditionIf")
         if (BuildConfig.FIREBASE_ENABLED) {
             Timber.d("Firebase is enabled, loading browse")
-            navGraph.startDestination = R.id.browseFragment
+            navGraph.setStartDestination(R.id.browseFragment)
         } else {
             Timber.d("Firebase is not enabled; showing notice")
-            navGraph.startDestination = R.id.noFirebaseFragment
+            navGraph.setStartDestination(R.id.noFirebaseFragment)
         }
 
         // Set the graph to trigger loading the start destination

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/castconnect/CastHelper.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/castconnect/CastHelper.kt
@@ -65,17 +65,4 @@ class CastHelper(val loadVideo: (Video) -> Unit, private val application: Applic
         // The intent was not recognized by the Cast SDK, so return false.
         return false
     }
-
-    companion object {
-        fun setMediaSessionTokenForCast(
-            mediaSession: MediaSessionCompat?,
-            mediaManager: MediaManager
-        ) {
-            if (mediaSession != null) {
-                mediaManager.setSessionCompatToken(mediaSession.sessionToken)
-            } else {
-                mediaManager.setSessionCompatToken(null)
-            }
-        }
-    }
 }

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/castconnect/CastMediaLoadCommandCallback.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/castconnect/CastMediaLoadCommandCallback.kt
@@ -48,31 +48,19 @@ class CastMediaLoadCommandCallback(
 
     override fun onLoad(
         senderId: String?,
-        mediaLoadRequestData: MediaLoadRequestData?
+        mediaLoadRequestData: MediaLoadRequestData
     ): Task<MediaLoadRequestData> {
-        return if (mediaLoadRequestData == null) {
-            // Throw MediaException to indicate load failure.
-            Tasks.forException(
-                MediaException(
-                    MediaError.Builder()
-                        .setDetailedErrorCode(MediaError.DetailedErrorCode.LOAD_FAILED)
-                        .setReason(MediaError.ERROR_REASON_INVALID_REQUEST)
-                        .build()
-                )
+        return Tasks.call {
+            var videoToPlay = convertLoadRequestToVideo(
+                mediaLoadRequestData, VideoRepositoryFactory.getVideoRepository(application)
             )
-        } else {
-            Tasks.call {
-                var videoToPlay = convertLoadRequestToVideo(
-                    mediaLoadRequestData, VideoRepositoryFactory.getVideoRepository(application)
-                )
-                if (videoToPlay != null) {
-                    onLoaded(videoToPlay, mediaLoadRequestData)
-                } else {
-                    Timber.w("Failed to convert cast load request to application-specific video")
-                }
-
-                mediaLoadRequestData
+            if (videoToPlay != null) {
+                onLoaded(videoToPlay, mediaLoadRequestData)
+            } else {
+                Timber.w("Failed to convert cast load request to application-specific video")
             }
+
+            mediaLoadRequestData
         }
     }
 

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/playback/PlaybackFragment.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/playback/PlaybackFragment.kt
@@ -25,15 +25,16 @@ import androidx.navigation.fragment.findNavController
 import com.android.tv.reference.R
 import com.android.tv.reference.castconnect.CastHelper
 import com.android.tv.reference.shared.datamodel.Video
-import com.google.android.exoplayer2.DefaultControlDispatcher
-import com.google.android.exoplayer2.ExoPlaybackException
 import com.google.android.exoplayer2.ExoPlayer
+import com.google.android.exoplayer2.ForwardingPlayer
 import com.google.android.exoplayer2.MediaItem
+import com.google.android.exoplayer2.PlaybackException
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.ext.leanback.LeanbackPlayerAdapter
 import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
+import com.google.android.exoplayer2.upstream.DefaultDataSource
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory
 import com.google.android.exoplayer2.util.Util
 import com.google.android.gms.cast.tv.CastReceiverContext
@@ -113,28 +114,32 @@ class PlaybackFragment : VideoSupportFragment() {
 
     override fun onDestroy() {
         super.onDestroy()
-
         // Releasing the mediaSession due to inactive playback and setting token for cast to null.
         mediaSession.release()
-        CastHelper.setMediaSessionTokenForCast(
-            /* mediaSession =*/ null,
-            CastReceiverContext.getInstance().mediaManager
-        )
+        CastReceiverContext.getInstance().mediaManager.setSessionCompatToken(null)
     }
 
     private fun initializePlayer() {
-        val dataSourceFactory = DefaultDataSourceFactory(
-            requireContext(),
-            Util.getUserAgent(requireContext(), getString(R.string.app_name))
-        )
+        val dataSourceFactory = DefaultDataSource.Factory(requireContext())
         val mediaSource = ProgressiveMediaSource.Factory(dataSourceFactory).
             createMediaSource(MediaItem.fromUri((video.videoUri)))
-        exoplayer = SimpleExoPlayer.Builder(requireContext()).build().apply {
+        exoplayer = ExoPlayer.Builder(requireContext()).build().apply {
             setMediaSource(mediaSource)
             prepare()
             addListener(PlayerEventListener())
             prepareGlue(this)
-            mediaSessionConnector.setPlayer(this)
+            mediaSessionConnector.setPlayer(object: ForwardingPlayer(this) {
+                override fun stop() {
+                    // Treat stop commands as pause, this keeps ExoPlayer, MediaSession, etc.
+                    // in memory to allow for quickly resuming. This also maintains the playback
+                    // position so that the user will resume from the current position when backing
+                    // out and returning to this video
+                    Timber.v("Playback stopped at $currentPosition")
+                    // This both prevents playback from starting automatically and pauses it if
+                    // it's already playing
+                    playWhenReady = false
+                }
+            })
             mediaSession.isActive = true
         }
 
@@ -176,25 +181,9 @@ class PlaybackFragment : VideoSupportFragment() {
 
         mediaSessionConnector = MediaSessionConnector(mediaSession).apply {
             setQueueNavigator(SingleVideoQueueNavigator(video, mediaSession))
-            setControlDispatcher(object : DefaultControlDispatcher() {
-                override fun dispatchStop(player: Player, reset: Boolean): Boolean {
-                    // Treat stop commands as pause, this keeps ExoPlayer, MediaSession, etc.
-                    // in memory to allow for quickly resuming. This also maintains the playback
-                    // position so that the user will resume from the current position when backing
-                    // out and returning to this video
-                    Timber.v("Playback stopped at ${player.currentPosition}")
-                    // This both prevents playback from starting automatically and pauses it if
-                    // it's already playing
-                    player.playWhenReady = false
-                    return true
-                }
-            })
         }
-
-        CastHelper.setMediaSessionTokenForCast(
-            mediaSession,
-            CastReceiverContext.getInstance().mediaManager
-        )
+        CastReceiverContext.getInstance().mediaManager.setSessionCompatToken(
+            mediaSession.sessionToken)
     }
 
     private fun startPlaybackFromWatchProgress(startPosition: Long) {
@@ -210,8 +199,8 @@ class PlaybackFragment : VideoSupportFragment() {
         //  episodic content.
     }
 
-    inner class PlayerEventListener : Player.EventListener {
-        override fun onPlayerError(error: ExoPlaybackException) {
+    inner class PlayerEventListener : Player.Listener {
+        override fun onPlayerError(error: PlaybackException) {
             Timber.w(error, "Playback error")
             viewModel.onStateChange(VideoPlaybackState.Error(video, error))
         }

--- a/ReferenceAppKotlin/app/src/test/AndroidManifest.xml
+++ b/ReferenceAppKotlin/app/src/test/AndroidManifest.xml
@@ -55,7 +55,9 @@
             android:required="false" />
 
 
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
 
             <!-- Used as the main entry point from the leanback launcher -->
             <intent-filter>

--- a/ReferenceAppKotlin/app/src/test/java/com/android/tv/reference/castconnect/CastHelperTest.kt
+++ b/ReferenceAppKotlin/app/src/test/java/com/android/tv/reference/castconnect/CastHelperTest.kt
@@ -72,22 +72,4 @@ class CastHelperTest {
          */
         assertThat(isCallbackInvoked).isFalse()
     }
-
-    @Test
-    fun setMediaSessionTokenForCast_createMediaSession() {
-        // There is no getter for CastReceiverContext because of which we need to use spy
-        val mediaManagerSpy = Mockito.spy(CastReceiverContext.getInstance().mediaManager)
-
-        CastHelper.setMediaSessionTokenForCast(mockMediaSession, mediaManagerSpy)
-        verify(mediaManagerSpy).setSessionCompatToken(mockMediaSession.sessionToken)
-    }
-
-    @Test
-    fun setMediaSessionTokenForCast_removeMediaSession() {
-        // There is no getter for CastReceiverContext because of which we need to use spy
-        val mediaManagerSpy = Mockito.spy(CastReceiverContext.getInstance().mediaManager)
-
-        CastHelper.setMediaSessionTokenForCast(null, mediaManagerSpy)
-        verify(mediaManagerSpy).setSessionCompatToken(null)
-    }
 }

--- a/ReferenceAppKotlin/build.gradle
+++ b/ReferenceAppKotlin/build.gradle
@@ -16,14 +16,14 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.32"
-    ext.nav_version = "2.3.5"
+    ext.kotlin_version = "1.6.10"
+    ext.nav_version = "2.4.1"
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"

--- a/ReferenceAppKotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/ReferenceAppKotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 23 11:15:09 PDT 2021
+#Wed Mar 23 15:53:23 UTC 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bumps the ExoPlayer version to the latest release as well as all other dependencies in preparation to migrating to AndroidX Media3.

The cast-tv dependency is still on 17.0.0 because the most recent version 19.0.1 has a nullability issue that can't be worked around with Kotlin AFAIK. Will update asap when the next release of cast-tv has landed and the bug is fixed (See internal:b/218604167). 