### PR TITLE
Migrate JetStream to version catalog.

### DIFF
--- a/JetStreamCompose/benchmark/build.gradle
+++ b/JetStreamCompose/benchmark/build.gradle
@@ -15,13 +15,13 @@
  */
 
 plugins {
-    id 'com.android.test'
-    id 'org.jetbrains.kotlin.android'
+    alias(libs.plugins.android.test)
+    alias(libs.plugins.kotlin.android)
 }
 
 android {
     namespace 'com.google.jetstream.benchmark'
-    compileSdk 33
+    compileSdk 34
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -54,12 +54,12 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.test.ext:junit:1.1.5'
-    implementation 'androidx.test.uiautomator:uiautomator:2.2.0'
+    implementation(libs.androidx.junit)
+    implementation(libs.androidx.uiautomator)
 
     // Support for TV activities with LEANBACK_LAUNCHER intent was added in 1.2.0-alpha03 release
     // Use 1.2.0-alpha03 or above versions for benchmarking TV apps
-    implementation 'androidx.benchmark:benchmark-macro-junit4:1.2.0-alpha14'
+    implementation(libs.androidx.benchmark.macro.junit4)
 }
 
 androidComponents {

--- a/JetStreamCompose/benchmark/src/main/java/com/google/jetstream/benchmark/BaselineProfileGenerator.kt
+++ b/JetStreamCompose/benchmark/src/main/java/com/google/jetstream/benchmark/BaselineProfileGenerator.kt
@@ -27,7 +27,7 @@ class BaselineProfileGenerator {
     val baselineProfileRule = BaselineProfileRule()
 
     @Test
-    fun startup() = baselineProfileRule.collectBaselineProfile(
+    fun startup() = baselineProfileRule.collect(
         packageName = JETSTREAM_PACKAGE_NAME
     ) {
         startActivityAndWait()

--- a/JetStreamCompose/build.gradle
+++ b/JetStreamCompose/build.gradle
@@ -15,22 +15,11 @@
  */
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    ext {
-        compose_compiler_version = "1.4.0"
-        compose_version = "1.4.3"
-        secrets_plugin_version = '2.0.1'
-    }
-    dependencies {
-        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:$secrets_plugin_version"
-    }
-}
-
 plugins {
-    id 'com.android.application' version '8.0.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
-    id 'com.android.test' version '8.0.2' apply false
-    id 'com.google.dagger.hilt.android' version '2.44' apply false
+    alias(libs.plugins.android.application) apply(false)
+    alias(libs.plugins.kotlin.android) apply(false)
+    alias(libs.plugins.android.test) apply(false)
+    alias(libs.plugins.hilt) apply(false)
 }
 
 task clean(type: Delete) {

--- a/JetStreamCompose/gradle/libs.versions.toml
+++ b/JetStreamCompose/gradle/libs.versions.toml
@@ -1,0 +1,53 @@
+[versions]
+activity-compose = "1.7.2"
+android-gradle-plugin = "8.1.0"
+android-test-plugin = "8.1.0"
+benchmark-macro-junit4 = "1.2.0-beta02"
+coil-compose = "2.4.0"
+compose-for-tv = "1.0.0-SNAPSHOT"
+compose-ui = "1.6.0-SNAPSHOT"
+core-ktx = "1.11.0-beta02"
+core-splashscreen = "1.0.1"
+gson = "2.9.1"
+hilt-navigation-compose = "1.0.0"
+hilt-android = "2.47"
+junit = "1.1.5"
+kotlin-android = "1.8.10"
+lifecycle-runtime-ktx = "2.6.1"
+material-icons-extended = "1.4.3"
+media3-ui = "1.1.0"
+media3-exoplayer = "1.1.0"
+navigation-compose = "2.6.0"
+profileinstaller = "1.3.1"
+uiautomator = "2.2.0"
+
+[libraries]
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
+androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "benchmark-macro-junit4" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
+androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
+androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
+androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junit" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle-runtime-ktx" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle-runtime-ktx" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle-runtime-ktx" }
+androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "material-icons-extended" }
+androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3-ui" }
+androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3-exoplayer" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
+androidx-profileinstaller = { module = "androidx.profileinstaller:profileinstaller", version.ref = "profileinstaller" }
+androidx-tv-foundation = { module = "androidx.tv:tv-foundation", version.ref = "compose-for-tv" }
+androidx-tv-material = { module = "androidx.tv:tv-material", version.ref = "compose-for-tv" }
+androidx-compose-ui-base = { module = "androidx.compose.ui:ui", version.ref = "compose-ui" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-ui" }
+androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil-compose" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt-android" }
+hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt-android"}
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref= "kotlin-android" }
+android-test = { id = "com.android.test", version.ref = "android-test-plugin" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt-android"}

--- a/JetStreamCompose/gradle/libs.versions.toml
+++ b/JetStreamCompose/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ android-gradle-plugin = "8.1.0"
 android-test-plugin = "8.1.0"
 benchmark-macro-junit4 = "1.2.0-beta02"
 coil-compose = "2.4.0"
+compose-bom = "2023.06.01"
 compose-for-tv = "1.0.0-SNAPSHOT"
 compose-ui = "1.6.0-SNAPSHOT"
 core-ktx = "1.11.0-beta02"
@@ -14,7 +15,6 @@ hilt-android = "2.47"
 junit = "1.1.5"
 kotlin-android = "1.8.10"
 lifecycle-runtime-ktx = "2.6.1"
-material-icons-extended = "1.4.3"
 media3-ui = "1.1.0"
 media3-exoplayer = "1.1.0"
 navigation-compose = "2.6.0"
@@ -24,6 +24,9 @@ uiautomator = "2.2.0"
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "benchmark-macro-junit4" }
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
+androidx-compose-ui-base = { module = "androidx.compose.ui:ui", version.ref = "compose-ui" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-ui" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
@@ -31,23 +34,21 @@ androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junit" }
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle-runtime-ktx" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle-runtime-ktx" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle-runtime-ktx" }
-androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "material-icons-extended" }
+androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3-ui" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3-exoplayer" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
 androidx-profileinstaller = { module = "androidx.profileinstaller:profileinstaller", version.ref = "profileinstaller" }
 androidx-tv-foundation = { module = "androidx.tv:tv-foundation", version.ref = "compose-for-tv" }
 androidx-tv-material = { module = "androidx.tv:tv-material", version.ref = "compose-for-tv" }
-androidx-compose-ui-base = { module = "androidx.compose.ui:ui", version.ref = "compose-ui" }
-androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-ui" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil-compose" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt-android" }
-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt-android"}
+hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt-android" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref= "kotlin-android" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin-android" }
 android-test = { id = "com.android.test", version.ref = "android-test-plugin" }
-hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt-android"}
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt-android" }

--- a/JetStreamCompose/jetstream/build.gradle
+++ b/JetStreamCompose/jetstream/build.gradle
@@ -94,6 +94,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation libs.androidx.lifecycle.runtime.compose
     implementation(libs.androidx.activity.compose)
+    implementation(platform(libs.androidx.compose.bom))
 
     // Compose UI libs (Using snapshot build for focus restoring APIs)
     //implementation(libs.androidx.)

--- a/JetStreamCompose/jetstream/build.gradle
+++ b/JetStreamCompose/jetstream/build.gradle
@@ -17,11 +17,10 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
     id 'kotlin-kapt'
-    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
-    id 'com.google.dagger.hilt.android'
+    alias(libs.plugins.hilt)
 }
 
 android {
@@ -70,7 +69,7 @@ android {
         buildConfig true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion compose_compiler_version
+        kotlinCompilerExtensionVersion "1.4.3"
     }
     packagingOptions {
         resources {
@@ -91,60 +90,47 @@ kapt {
 }
 
 dependencies {
-    def tv_compose_version = "1.0.0-SNAPSHOT"
-//    def tv_compose_version = "1.0.0-alpha06"
-    def core_ktx_version = "1.10.1"
-    def lifecycle_version = "2.6.1"
-    def compose_activity_version = "1.7.2"
-    def splash_screen_version = "1.0.1"
-    def nav_version = "2.6.0"
-    def gson_version = "2.9.1"
-    def media3_version = "1.1.0"
-    def compose_ui_version = "1.6.0-SNAPSHOT"
-    def profileinstaller_version = "1.3.1"
-    def hilt_version = "2.47"
-    def hilt_compose = "1.0.0"
-
-    implementation("androidx.core:core-ktx:$core_ktx_version")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version")
-    implementation "androidx.lifecycle:lifecycle-runtime-compose:$lifecycle_version"
-    implementation("androidx.activity:activity-compose:$compose_activity_version")
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation libs.androidx.lifecycle.runtime.compose
+    implementation(libs.androidx.activity.compose)
 
     // Compose UI libs (Using snapshot build for focus restoring APIs)
-    implementation("androidx.compose.ui:ui:$compose_ui_version")
-    implementation("androidx.compose.ui:ui-tooling-preview:$compose_ui_version")
+    //implementation(libs.androidx.)
+    implementation(libs.androidx.compose.ui.base)
+    implementation(libs.androidx.compose.ui.tooling.preview)
 
     // extra material icons
-    implementation("androidx.compose.material:material-icons-extended:$compose_version")
+    implementation(libs.androidx.material.icons.extended)
 
     // TV Compose
-    implementation("androidx.tv:tv-foundation:$tv_compose_version")
-    implementation("androidx.tv:tv-material:$tv_compose_version")
+    implementation(libs.androidx.tv.foundation)
+    implementation(libs.androidx.tv.material)
 
     // ViewModel in Compose
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version")
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
 
     // Compose Navigation
-    implementation("androidx.navigation:navigation-compose:$nav_version")
+    implementation(libs.androidx.navigation.compose)
 
     // Coil
-    implementation("io.coil-kt:coil-compose:2.4.0")
+    implementation(libs.coil.compose)
 
     // GSON
-    implementation("com.google.code.gson:gson:$gson_version")
+    implementation(libs.gson)
 
     // Media3
-    implementation("androidx.media3:media3-exoplayer:$media3_version")
-    implementation("androidx.media3:media3-ui:$media3_version")
+    implementation(libs.androidx.media3.exoplayer)
+    implementation(libs.androidx.media3.ui)
 
     // SplashScreen
-    implementation("androidx.core:core-splashscreen:$splash_screen_version")
+    implementation(libs.androidx.core.splashscreen)
 
     // Hilt
-    implementation("com.google.dagger:hilt-android:$hilt_version")
-    implementation("androidx.hilt:hilt-navigation-compose:$hilt_compose")
-    kapt("com.google.dagger:hilt-compiler:$hilt_version")
+    implementation(libs.hilt.android)
+    implementation(libs.androidx.hilt.navigation.compose)
+    kapt(libs.hilt.compiler)
 
     // Baseline profile installer
-    implementation("androidx.profileinstaller:profileinstaller:$profileinstaller_version")
+    implementation(libs.androidx.profileinstaller)
 }


### PR DESCRIPTION
This PR migrates JetStream to version catalog. In addition to that,  the following things are delivered by the PR:

- Ext block is removed. 
- Some libraries are updated, including Compose.
- Fix a build error on BaselineProfileGenator.kt due to the update of androidx.benchmark:benchmark-macro-junit4
