### PR TITLE
feat: use engage-sdk for continue watching

### DIFF
--- a/ReferenceAppKotlin/app/build.gradle
+++ b/ReferenceAppKotlin/app/build.gradle
@@ -122,6 +122,9 @@ dependencies {
     implementation("com.squareup.moshi:moshi-kotlin:1.13.0")
     kapt("com.squareup.moshi:moshi-kotlin-codegen:1.13.0")
 
+    // Engage SDK
+    implementation "com.google.android.engage:engage-core:1.4.0"
+
     // Retrofit for HTTP requests
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/MainActivity.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/MainActivity.kt
@@ -30,6 +30,7 @@ import com.android.tv.reference.deeplink.DeepLinkViewModel
 import com.android.tv.reference.deeplink.DeepLinkViewModelFactory
 import com.android.tv.reference.shared.datamodel.Video
 import com.android.tv.reference.shared.util.Result
+import com.android.tv.reference.watchnext.Publisher
 import timber.log.Timber
 
 /**
@@ -145,5 +146,10 @@ class MainActivity : FragmentActivity() {
                 video
             )
         )
+    }
+
+    override fun onStop() {
+        super.onStop()
+        Publisher.publishPeriodically(applicationContext)
     }
 }

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/ClusterRequestFactory.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/ClusterRequestFactory.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.tv.reference.watchnext
+
+import android.content.Context
+import com.android.tv.reference.shared.datamodel.VideoType
+import com.google.android.engage.common.datamodel.ContinuationCluster
+import com.google.android.engage.service.PublishContinuationClusterRequest
+
+/**
+ * Class in charge of constructing the publishing requests and sending them to their respective
+ * publishers
+ */
+class ClusterRequestFactory(context: Context) {
+
+    private val engageWatchNextService = EngageWatchNextService.getInstance(context)
+
+    /**
+     * [constructContinuationClusterRequest] returns a [PublishContinuationClusterRequest] to be used
+     * by the [EngageServiceWorker] to publish Continuations clusters
+     *
+     * @return PublishContinuationClusterRequest
+     */
+    fun constructContinuationClusterRequest(): PublishContinuationClusterRequest {
+        val continuationList = engageWatchNextService.getAllWatchNextVideos()
+        val continuationCluster = ContinuationCluster.Builder()
+        for (watchNextVideo in continuationList) {
+            val videoType = watchNextVideo.video.videoType
+            if (videoType == VideoType.EPISODE || videoType == VideoType.MOVIE) {
+                continuationCluster.addEntity(
+                    VideoToEngageEntityConverter.convertVideo(
+                        watchNextVideo
+                    )
+                )
+            }
+        }
+        return PublishContinuationClusterRequest.Builder()
+            .setContinuationCluster(continuationCluster.build())
+            .build()
+    }
+}

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/Constants.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/Constants.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.tv.reference.watchnext
+
+/** Constants that are to be used as reference for publishing guidelines */
+object Constants {
+    const val MAX_PUBLISHING_ATTEMPTS: Int = 5
+
+    const val WORKER_NAME_CONTINUATION: String = "Upload Continuation"
+
+    const val PERIODIC_WORKER_NAME_CONTINUATION: String = "Periodically Upload Continuation"
+
+    const val PUBLISH_TYPE: String = "PUBLISH_TYPE"
+    const val PUBLISH_TYPE_CONTINUATION = "PUBLISH_CONTINUATION"
+}

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/EngageServiceBroadcastReceiver.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/EngageServiceBroadcastReceiver.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.tv.reference.watchnext
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.android.tv.reference.watchnext.Publisher.publishContinuationClusters
+import com.google.android.engage.service.Intents.ACTION_PUBLISH_CONTINUATION
+
+/** Broadcast Receiver to trigger a one time publish of clusters. */
+class EngageServiceBroadcastReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (intent == null || context == null) {
+            return
+        }
+        when (intent.action) {
+            ACTION_PUBLISH_CONTINUATION -> publishContinuationClusters(context)
+            else -> Log.e(TAG, "onReceive: Received unrecognized intent: $intent")
+        }
+    }
+
+    private companion object {
+        const val TAG = "EngageBroadcastReceiver"
+    }
+}

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/EngageServiceWorker.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/EngageServiceWorker.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.tv.reference.watchnext
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.android.tv.reference.watchnext.Constants.PUBLISH_TYPE
+import com.android.tv.reference.watchnext.Constants.PUBLISH_TYPE_CONTINUATION
+import com.google.android.engage.service.AppEngageException
+import com.google.android.engage.service.AppEngagePublishClient
+import com.google.android.engage.service.AppEngagePublishStatusCode
+import com.google.android.engage.service.PublishStatusRequest
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.common.annotations.VisibleForTesting
+import timber.log.Timber
+
+/**
+ * [EngageServiceWorker] is a [Worker] class that is tasked with publishing cluster
+ * requests to Engage Service
+ */
+class EngageServiceWorker(
+    context: Context,
+    workerParams: WorkerParameters,
+) : Worker(context, workerParams) {
+
+    @VisibleForTesting
+    constructor(
+        context: Context,
+        workerParams: WorkerParameters,
+        client: AppEngagePublishClient,
+    ) : this(context, workerParams) {
+        this.client = client
+    }
+
+    val TAG = "ENGAGE_SERVICE_WORKER"
+    private var client = AppEngagePublishClient(context)
+    private val clusterRequestFactory = ClusterRequestFactory(context)
+
+    /**
+     * [doWork] is the entry point for the [EngageServiceWorker], and differentiates between
+     * publishing tasks of each cluster
+     */
+    override fun doWork(): Result {
+        // If too many publishing attempts have failed, do not attempt to publish again.
+        if (runAttemptCount > Constants.MAX_PUBLISHING_ATTEMPTS) {
+            return Result.failure()
+        }
+
+        Timber.i("Checking for Engage Service availability")
+
+        // Check if engage service is available before publishing.
+        val isAvailable = Tasks.await(client.isServiceAvailable)
+
+        // If the service is not available, do not attempt to publish and indicate failure.
+        if (!isAvailable) {
+            Timber.e("Engage service is not available")
+            return Result.failure()
+        }
+
+        Timber.i("Engage Service is available. Proceeding to publish clusters")
+
+        // The cluster to publish must be passed into the worker through the input data.
+        // This value must be one of the predefined values indicated a valid cluster to publish. Instead
+        // of using one worker with flags to determine what cluster to publish, you may also choose to
+        // your separate workers to publish different clusters; use whichever approach better fits your
+        // app architecture.
+        return when (inputData.getString(PUBLISH_TYPE)) {
+            PUBLISH_TYPE_CONTINUATION -> publishContinuation()
+            else -> throw IllegalArgumentException("Bad publish type")
+        }
+    }
+
+    /**
+     * [publishContinuation] publishes continuation clusters and returns the result of the attempt to
+     * publish the continuation clusters if the user is signed in. If the user is signed out it
+     * instead publishes a request to delete the continuation cluster that had previously been
+     * published.
+     *
+     * @return result Result of publishing a continuation cluster, or continuation cluster deletion
+     */
+    private fun publishContinuation(): Result {
+        val publishTask: Task<Void> = client.publishContinuationCluster(
+            clusterRequestFactory.constructContinuationClusterRequest()
+        )
+        val statusCode: Int = AppEngagePublishStatusCode.PUBLISHED
+        return publishAndProvideResult(publishTask, statusCode)
+    }
+
+    /**
+     * [publishAndProvideResult] is a method that is in charge of publishing a given task
+     *
+     * @param publishTask A task to publish some cluster or delete some cluster
+     * @param publishStatusCode Publish status code to set through Engage.
+     * @return publishResult Result of [publishTask]
+     */
+    private fun publishAndProvideResult(
+        publishTask: Task<Void>,
+        publishStatusCode: Int
+    ): Result {
+        setPublishStatusCode(publishStatusCode)
+
+        // Result initialized to success, it is changed to retry or failure if an exception occurs.
+        var result: Result = Result.success()
+        try {
+            // An AppEngageException may occur while publishing, so we may not be able to await the
+            // result.
+            Tasks.await(publishTask)
+        } catch (publishException: Exception) {
+            Publisher.logPublishing(publishException as AppEngageException)
+            // Some errors are recoverable, such as a threading issue, some are unrecoverable
+            // such as a cluster not containing all necessary fields. If an error is recoverable, we
+            // should attempt to publish again. Setting the  result to retry means WorkManager will
+            // attempt to run the worker again, thus attempting to publish again.
+            result =
+                if (Publisher.isErrorRecoverable(publishException))
+                    Result.retry()
+                else
+                    Result.failure()
+        }
+        // This result is returned back to doWork.
+        return result
+    }
+
+    /**
+     * [setPublishStatusCode] method is in charge of updating the publish status code, which monitors
+     * the health of the integration with EngageSDK
+     *
+     * @param statusCode PublishStatus code to be set through Engage.
+     */
+    private fun setPublishStatusCode(statusCode: Int) {
+        client
+            .updatePublishStatus(PublishStatusRequest.Builder().setStatusCode(statusCode).build())
+            .addOnSuccessListener {
+                Log.i(TAG, "Successfully updated publish status code to $statusCode")
+            }
+            .addOnFailureListener { exception ->
+                Log.e(
+                    TAG,
+                    "Failed to update publish status code to $statusCode\n${exception.stackTrace}"
+                )
+            }
+    }
+}

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/EngageWatchNextService.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/EngageWatchNextService.kt
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.tv.reference.watchnext
+
+import android.app.Application
+import android.content.Context
+import android.media.tv.TvContract
+import com.android.tv.reference.repository.VideoRepositoryFactory
+import com.android.tv.reference.shared.datamodel.Video
+import com.android.tv.reference.shared.datamodel.VideoType
+import timber.log.Timber
+
+/**
+ * A services which synchronizes watch next videos state with your video repository.
+ */
+class EngageWatchNextService private constructor(private val context: Context) {
+    private var watchNextVideos: MutableList<WatchNextVideo> = mutableListOf()
+
+    /**
+     * Returns all videos in the watch next queue
+     */
+    fun getAllWatchNextVideos(): List<WatchNextVideo> {
+        return watchNextVideos.toList()
+    }
+
+    fun handleVideoPlaybackStateChange(
+        videoId: String?,
+        currentWatchPosition: Long,
+        playerState: String,
+    ) {
+        if (videoId.isNullOrEmpty()) {
+            Timber.e("Error.Invalid entry for Watch Next. videoId: $videoId")
+            return
+        }
+
+        // Check for invalid player state.
+        if ((playerState != WatchNextHelper.PLAY_STATE_PAUSED) and
+            (playerState != WatchNextHelper.PLAY_STATE_ENDED)
+        ) {
+            Timber.e("Error.Invalid entry for Watch Next. Player state: $playerState")
+            return
+        }
+
+        val video =
+            VideoRepositoryFactory.getVideoRepository(context.applicationContext as Application)
+                .getVideoById(videoId)
+
+        when (video?.videoType) {
+            VideoType.MOVIE -> {
+                Timber.v("Add Movie to Watch Next : id = ${video.id}")
+                handleWatchNextForMovie(
+                    video = video,
+                    playerState = playerState,
+                    watchPosition = currentWatchPosition.toInt(),
+                )
+            }
+
+            VideoType.EPISODE -> {
+                Timber.v("Add Episode to Watch Next : id = ${video.id}")
+                handleWatchNextForTvEpisode(
+                    video = video,
+                    currentWatchPosition = currentWatchPosition.toInt(),
+                    playerState = playerState,
+                )
+            }
+
+            VideoType.CLIP -> Timber.w(
+                "NOT recommended to add Clips / Trailers /Short videos to Watch Next "
+            )
+
+            else -> Timber.e("Invalid category for Video Type: ${video?.videoType}")
+        }
+    }
+
+    private fun handleWatchNextForMovie(video: Video, playerState: String, watchPosition: Int) {
+        Timber.v("Adding/remove movie to Watch Next. Video Name: ${video.name}")
+
+        when {
+            // If movie has finished, remove from Watch Next channel.
+            (playerState == WatchNextHelper.PLAY_STATE_ENDED) or
+                video.isAfterEndCreditsPosition(watchPosition.toLong()) -> {
+                WatchNextHelper.removeVideoFromWatchNext(context, video)
+            }
+
+            // Add or update unfinished movie to Watch Next channel.
+            WatchNextHelper.hasVideoStarted(video.duration(), watchPosition) -> {
+                insertOrUpdateIntoWatchNext(
+                    video,
+                    watchPosition,
+                    TvContract.WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE
+                )
+            }
+
+            else -> {
+                Timber.w(
+                    "Video not started yet. Can't add to WatchNext.watchPosition: %s, duration: %d",
+                    watchPosition,
+                    video.duration().toMillis()
+                )
+            }
+        }
+    }
+
+    private fun handleWatchNextForTvEpisode(
+        video: Video,
+        currentWatchPosition: Int,
+        playerState: String,
+    ) {
+        Timber.v("Adding/remove episode to Watch Next. Video Name: ${video.name}")
+
+        when {
+            // If episode has finished, remove from Watch Next channel.
+            (playerState == WatchNextHelper.PLAY_STATE_ENDED) or
+                video.isAfterEndCreditsPosition(currentWatchPosition.toLong()) -> {
+                removeFromWatchNext(video)
+
+                // Add next episode from TV series.
+                VideoRepositoryFactory
+                    .getVideoRepository(context.applicationContext as Application)
+                    .getNextEpisodeInSeries(video)?.let {
+                    insertOrUpdateIntoWatchNext(
+                        it,
+                        currentWatchPosition,
+                        TvContract.WatchNextPrograms.WATCH_NEXT_TYPE_NEXT
+                    )
+                }
+            }
+
+            // Add or update unfinished episode to Watch Next channel.
+            WatchNextHelper.hasVideoStarted(video.duration(), currentWatchPosition) -> {
+                insertOrUpdateIntoWatchNext(
+                    video,
+                    currentWatchPosition,
+                    TvContract.WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE
+                )
+            }
+
+            else -> {
+                Timber.w(
+                    "Video not started yet. Can't add to WatchNext.watchPosition: %s, duration: %d",
+                    currentWatchPosition,
+                    video.duration().toMillis()
+                )
+            }
+        }
+    }
+
+    /**
+     * Updates or adds a video entity from the watch next list
+     */
+    private fun insertOrUpdateIntoWatchNext(
+        video: Video,
+        watchPosition: Int,
+        watchNextType: Int
+    ) {
+        if (video.videoType != VideoType.MOVIE && video.videoType != VideoType.EPISODE) {
+            throw IllegalArgumentException(
+                "Watch Next is not supported for Video Type: ${video.videoType}"
+            )
+        }
+
+        val existingVideoIndex = watchNextVideos.indexOfFirst { it.video.id == video.id }
+        val watchNextVideo = WatchNextVideo(
+            video = video,
+            watchPosition = watchPosition,
+            watchNextType = watchNextType,
+        )
+        if (existingVideoIndex == -1) {
+            watchNextVideos.add(watchNextVideo)
+        } else {
+            watchNextVideos[existingVideoIndex] = watchNextVideo
+        }
+    }
+
+    /**
+     * Removes a video entity from the watch next list
+     */
+    private fun removeFromWatchNext(video: Video) {
+        watchNextVideos = watchNextVideos.filter { it.video.id != video.id }.toMutableList()
+    }
+
+    companion object {
+        @Volatile
+        private var instance: EngageWatchNextService? = null
+
+        fun getInstance(context: Context): EngageWatchNextService {
+            if (instance == null) {
+                synchronized(this) {
+                    if (instance == null) {
+                        instance = EngageWatchNextService(context)
+                    }
+                }
+            }
+            return instance!!
+        }
+
+        data class WatchNextVideo(
+            val video: Video,
+            val watchPosition: Int,
+            val watchNextType: Int
+        )
+    }
+}

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/Publisher.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/Publisher.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.tv.reference.watchnext
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Data
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
+import androidx.work.PeriodicWorkRequest
+import androidx.work.WorkManager
+import com.android.tv.reference.watchnext.Constants.PERIODIC_WORKER_NAME_CONTINUATION
+import com.android.tv.reference.watchnext.Constants.PUBLISH_TYPE
+import com.android.tv.reference.watchnext.Constants.PUBLISH_TYPE_CONTINUATION
+import com.android.tv.reference.watchnext.Constants.WORKER_NAME_CONTINUATION
+import com.google.android.engage.service.AppEngageErrorCode
+import com.google.android.engage.service.AppEngageException
+import java.util.concurrent.TimeUnit
+
+object Publisher {
+    private const val TAG = "PUBLISHER:"
+
+    /**
+     * Sets continuation cluster to the appropriate state by publishing or deleting the clusters.
+     * This occurs immediately then once every 24 hours.
+     *
+     * @param context Application's context.
+     */
+    fun publishPeriodically(context: Context) {
+        periodicallyCallEngageServiceWorker(
+            PERIODIC_WORKER_NAME_CONTINUATION,
+            PUBLISH_TYPE_CONTINUATION,
+            context
+        )
+    }
+
+    /**
+     * Sets continuation cluster and publish status to the appropriate state using WorkManager. More
+     * detail on what the appropriate state is described in {@link
+     * com.google.samples.quickstart.engagesdksamples.watch.publish.Publisher#publishPeriodically(Context)}.
+     *
+     * @param context Application's context
+     */
+    fun publishContinuationClusters(context: Context) {
+        queueOneTimeEngageServiceWorker(
+            WORKER_NAME_CONTINUATION,
+            PUBLISH_TYPE_CONTINUATION,
+            context
+        )
+    }
+
+    private fun periodicallyCallEngageServiceWorker(
+        workerName: String,
+        publishType: String,
+        context: Context
+    ) {
+        val data = Data.Builder().apply {
+            putString(PUBLISH_TYPE, publishType)
+        }.build()
+
+        val workRequest =
+            PeriodicWorkRequest.Builder(
+                EngageServiceWorker::class.java,
+                /* repeatInterval=         */ 24,
+                /* repeatIntervalTimeUnit= */ TimeUnit.HOURS
+            )
+                .setInputData(data)
+                .build()
+        WorkManager.getInstance(context)
+            .enqueueUniquePeriodicWork(
+                workerName,
+                ExistingPeriodicWorkPolicy.REPLACE,
+                workRequest
+            )
+
+    }
+
+    private fun queueOneTimeEngageServiceWorker(
+        workerName: String,
+        publishType: String,
+        context: Context
+    ) {
+        val data = Data.Builder().apply {
+            putString(PUBLISH_TYPE, publishType)
+        }.build()
+
+        val workRequest = OneTimeWorkRequest.Builder(EngageServiceWorker::class.java)
+            .setInputData(data)
+            .build()
+
+        WorkManager.getInstance(context)
+            .enqueueUniqueWork(workerName, ExistingWorkPolicy.REPLACE, workRequest)
+    }
+
+    fun logPublishing(publishingException: AppEngageException) {
+        val logMessage =
+            when (publishingException.errorCode) {
+                AppEngageErrorCode.SERVICE_NOT_FOUND ->
+                    "SERVICE_NOT_FOUND - The service is not available on the given device"
+
+                AppEngageErrorCode.SERVICE_CALL_EXECUTION_FAILURE ->
+                    "SERVICE_CALL_EXECUTION_FAILURE - The task execution failed due to threading " +
+                            "issues, can be retired"
+
+                AppEngageErrorCode.SERVICE_NOT_AVAILABLE ->
+                    "SERVICE_NOT_AVAILABLE - The service is available on the given device, but " +
+                            "not available at the time of the call"
+
+                AppEngageErrorCode.SERVICE_CALL_PERMISSION_DENIED ->
+                    "SERVICE_CALL_PERMISSION_DENIED - The The caller is not allowed to make " +
+                            "the service call"
+
+                AppEngageErrorCode.SERVICE_CALL_INVALID_ARGUMENT ->
+                    "SERVICE_CALL_INVALID_ARGUMENT - The request contains invalid data (e.g. " +
+                            "more than allowed number of clusters"
+
+                AppEngageErrorCode.SERVICE_CALL_INTERNAL ->
+                    "SERVICE_CALL_INTERNAL - There is an error on the service side"
+
+                AppEngageErrorCode.SERVICE_CALL_RESOURCE_EXHAUSTED ->
+                    "SERVICE_CALL_RESOURCE_EXHAUSTED - The service call is made too frequently"
+
+                else -> "An unknown error has occurred"
+            }
+        Log.d(TAG, logMessage)
+    }
+
+    fun isErrorRecoverable(publishingException: AppEngageException): Boolean {
+        return when (publishingException.errorCode) {
+            // Recoverable Error codes
+            AppEngageErrorCode.SERVICE_CALL_EXECUTION_FAILURE,
+            AppEngageErrorCode.SERVICE_CALL_INTERNAL,
+            AppEngageErrorCode.SERVICE_CALL_RESOURCE_EXHAUSTED -> true
+            // Non recoverable error codes
+            AppEngageErrorCode.SERVICE_NOT_FOUND,
+            AppEngageErrorCode.SERVICE_CALL_INVALID_ARGUMENT,
+            AppEngageErrorCode.SERVICE_CALL_PERMISSION_DENIED,
+            AppEngageErrorCode.SERVICE_NOT_AVAILABLE -> false
+
+            else -> throw IllegalArgumentException(publishingException.localizedMessage)
+        }
+    }
+}

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/VideoToEngageEntityConverter.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/VideoToEngageEntityConverter.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.tv.reference.watchnext
+
+import android.net.Uri
+import androidx.tvprovider.media.tv.TvContractCompat.WatchNextPrograms
+import com.android.tv.reference.shared.datamodel.Video
+import com.android.tv.reference.shared.datamodel.VideoType
+import com.android.tv.reference.watchnext.EngageWatchNextService.Companion.WatchNextVideo
+import com.google.android.engage.common.datamodel.Image
+import com.google.android.engage.video.datamodel.MovieEntity
+import com.google.android.engage.video.datamodel.TvEpisodeEntity
+import com.google.android.engage.video.datamodel.VideoEntity
+import com.google.android.engage.video.datamodel.WatchNextType
+
+object VideoToEngageEntityConverter {
+
+    fun convertVideo(watchNextVideo: WatchNextVideo): VideoEntity {
+        val video = watchNextVideo.video
+        val watchPosition = watchNextVideo.watchPosition
+        val watchNextType = watchNextVideo.watchNextType
+
+        return when (video.videoType) {
+            VideoType.MOVIE -> convertMovieEntity(
+                video = video,
+                watchPosition = watchPosition,
+                watchNextType = watchNextType
+            )
+
+            VideoType.EPISODE -> convertTvEpisodeEntity(
+                video = video,
+                watchPosition = watchPosition,
+                watchNextType = watchNextType
+            )
+
+            else -> {
+                throw IllegalArgumentException(
+                    "Conversion is not supported for Video Type: ${video.videoType}"
+                )
+            }
+        }
+    }
+
+    private fun convertTvEpisodeEntity(
+        video: Video,
+        watchPosition: Int,
+        watchNextType: Int
+    ): TvEpisodeEntity {
+        return TvEpisodeEntity
+            .Builder()
+            .setWatchNextType(convertToEngageWatchNextType(watchNextType))
+            .setLastPlayBackPositionTimeMillis(watchPosition.toLong())
+            .setLastEngagementTimeMillis(System.currentTimeMillis())
+            .setName(video.name)
+            .setDurationMillis(video.duration.toLong())
+            .addPosterImage(Image.Builder().setImageUri(Uri.parse(video.thumbnailUri)).build())
+            .setPlayBackUri(Uri.parse(video.uri))
+            .setEntityId(video.id)
+            .setSeasonNumber(video.seasonNumber)
+            .setSeasonTitle("${video.category} Season ${video.seasonNumber}")
+            .setEpisodeDisplayNumber(video.name)
+            .build()
+    }
+
+    private fun convertMovieEntity(
+        video: Video,
+        watchPosition: Int,
+        watchNextType: Int
+    ): MovieEntity {
+        return MovieEntity
+            .Builder()
+            .setWatchNextType(convertToEngageWatchNextType(watchNextType))
+            .setLastPlayBackPositionTimeMillis(watchPosition.toLong())
+            .setLastEngagementTimeMillis(System.currentTimeMillis())
+            .setName(video.name)
+            .setDurationMillis(video.duration.toLong())
+            .addPosterImage(Image.Builder().setImageUri(Uri.parse(video.thumbnailUri)).build())
+            .setPlayBackUri(Uri.parse(video.uri))
+            .setEntityId(video.id)
+            .build()
+    }
+
+    private fun convertToEngageWatchNextType(watchNextType: Int): Int {
+        return when (watchNextType) {
+            WatchNextPrograms.WATCH_NEXT_TYPE_NEXT -> WatchNextType.TYPE_NEXT
+            WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE -> WatchNextType.TYPE_CONTINUE
+            WatchNextPrograms.WATCH_NEXT_TYPE_NEW -> WatchNextType.TYPE_NEW
+            else -> WatchNextType.TYPE_UNKNOWN
+        }
+    }
+}

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/WatchNextHelper.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/WatchNextHelper.kt
@@ -120,7 +120,7 @@ object WatchNextHelper {
      * whichever timestamp is earlier.
      * https://developer.android.com/training/tv/discovery/guidelines-app-developers
      */
-    private fun hasVideoStarted(duration: Duration, currentPosition: Int): Boolean {
+    internal fun hasVideoStarted(duration: Duration, currentPosition: Int): Boolean {
         val durationInMilliSeconds = duration.toMillis().toInt()
         // Return true if either X minutes or Y % have passed
         // Following formatting spans over multiple lines to accommodate max 100 limit

--- a/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/WatchNextPlaybackStateListener.kt
+++ b/ReferenceAppKotlin/app/src/main/java/com/android/tv/reference/watchnext/WatchNextPlaybackStateListener.kt
@@ -46,19 +46,40 @@ class WatchNextPlaybackStateListener(private val context: Context) : PlaybackSta
 
         // Set relevant data about playback state and video.
         val watchData = Data.Builder().apply {
-            putString(WatchNextHelper.VIDEO_ID, video.id)
-            putLong(WatchNextHelper.CURRENT_POSITION, position)
-            putLong(WatchNextHelper.DURATION, video.duration().toMillis())
-            putString(WatchNextHelper.PLAYER_STATE, playerState)
+            putString(Constants.PUBLISH_TYPE, Constants.PUBLISH_TYPE_CONTINUATION)
         }.build()
+
+        EngageWatchNextService.getInstance(context).handleVideoPlaybackStateChange(
+            videoId = video.id,
+            currentWatchPosition = position,
+            playerState = playerState,
+        )
 
         // Run on a background thread to process playback states and do relevant operations for
         // Watch Next.
-        Timber.d("Trigger WorkManager with updated watchData $watchData")
-        WorkManager.getInstance(context.applicationContext).enqueue(
-            OneTimeWorkRequest.Builder(WatchNextWorker::class.java)
-                .setInputData(watchData)
-                .build()
-        )
+        Timber.d("Trigger WorkManager with updated watchData $watchData using Engage SDK")
+        WorkManager.getInstance(context.applicationContext)
+            .enqueue(
+                OneTimeWorkRequest.Builder(EngageServiceWorker::class.java)
+                    .setInputData(watchData)
+                    .build()
+            )
+
+        // Set relevant data about playback state and video.
+//        val watchData = Data.Builder().apply {
+//            putString(WatchNextHelper.VIDEO_ID, video.id)
+//            putLong(WatchNextHelper.CURRENT_POSITION, position)
+//            putLong(WatchNextHelper.DURATION, video.duration().toMillis())
+//            putString(WatchNextHelper.PLAYER_STATE, playerState)
+//        }.build()
+
+        // Run on a background thread to process playback states and do relevant operations for
+        // Watch Next.
+//        Timber.d("Trigger WorkManager with updated watchData $watchData using TvProvider")
+//        WorkManager.getInstance(context.applicationContext).enqueue(
+//            OneTimeWorkRequest.Builder(WatchNextWorker::class.java)
+//                .setInputData(watchData)
+//                .build()
+//        )
     }
 }

--- a/ReferenceAppKotlin/build.gradle
+++ b/ReferenceAppKotlin/build.gradle
@@ -40,6 +40,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url("/tmp/engage_m2/") }
     }
 }
 

--- a/ReferenceAppKotlin/build.gradle
+++ b/ReferenceAppKotlin/build.gradle
@@ -40,6 +40,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        // TODO: Remove this once EngageSDK 1.4.0 is published
         maven { url("/tmp/engage_m2/") }
     }
 }


### PR DESCRIPTION
This Pull request integrates Engage SDK with TV samples app. In the current implementation, we are making use of `androidx.tvprovider` to update the Watch Next program row on a TV device. Since `androidx.tvprovider` is no longer maintained and we are now moving towards cross-device continue watching, we are migrating to making use of Engage SDK to publish to the watch next program row on a TV device.