### PR TITLE
Fix so focus stays on Featured Movies carousel while flipping rapidly [JetStreamCompose]

### DIFF
--- a/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/home/FeaturedMoviesCarousel.kt
+++ b/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/home/FeaturedMoviesCarousel.kt
@@ -121,10 +121,16 @@ fun FeaturedMoviesCarousel(
                 activeItemIndex = carouselState.activeItemIndex
             )
         },
-        contentTransformStartToEnd = fadeIn(tween(durationMillis = 1000))
-            .togetherWith(fadeOut(tween(durationMillis = 1000))),
-        contentTransformEndToStart = fadeIn(tween(durationMillis = 1000))
-            .togetherWith(fadeOut(tween(durationMillis = 1000))),
+        contentTransformStartToEnd = slideIn(tween(100, easing = LinearOutSlowInEasing)) {
+            IntOffset(it.width, 0)
+        }.togetherWith(slideOut(tween(100, easing = FastOutSlowInEasing)) {
+            IntOffset(0, 0)
+        }),
+        contentTransformEndToStart = slideIn(tween(100, easing = LinearOutSlowInEasing)) {
+            IntOffset(it.width, 0)
+        }.togetherWith(slideOut(tween(100, easing = FastOutSlowInEasing)) {
+            IntOffset(0, 0)
+        }),
         content = { index ->
             val movie = movies[index]
             // background


### PR DESCRIPTION
Found an issue when rapidly cycling through the Featured Movies carousel. The focus would jump either up to the TopTabBar or below to the Trending rail (depending on the direction the carousel is being cycled). 

Removing the Watch Now button avoids the issue, but it isn't clear why. I didn't go with this fix because it would be removing functionality.

Instead I found that replacing the type of ContentTransform for contentTransformStartToEnd and contentTransformEndToStart animations worked around the issue. Specifically using slide instead of fade and shortening the transition to 100ms instead of 1000ms.

Unclear exactly why the slide transitions don't have the same issue (at least with 100ms duration) as the fade transitions, but this seems like an acceptable cosmetic-only change. I tried reducing the fade transitions to 100ms, but the issue still some times occurs and no animation is noticeable at such a small duration. Increasing the new slide transition to 1000s does cause the same focus issue, but the animation looks good at 100ms so there is no problem.

Example of issue and fix:
https://github.com/android/tv-samples/assets/11371505/9c51f6b8-ca43-4fff-b73a-7f8db504c2ca


Device:
- Emulator
- Android TV 4k
- API 34

