### PR TITLE
Fix #157: Avoiding seekBack and seekForward, while controls are visible

### DIFF
--- a/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/videoPlayer/VideoPlayerScreen.kt
+++ b/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/videoPlayer/VideoPlayerScreen.kt
@@ -281,12 +281,16 @@ private fun Modifier.dPadEvents(
     pulseState: VideoPlayerPulseState
 ): Modifier = this.handleDPadKeyEvents(
         onLeft = {
-            exoPlayer.seekBack()
-            pulseState.setType(BACK)
+            if (!videoPlayerState.controlsVisible) {
+                exoPlayer.seekBack()
+                pulseState.setType(BACK)
+            }
         },
         onRight = {
-            exoPlayer.seekForward()
-            pulseState.setType(FORWARD)
+            if (!videoPlayerState.controlsVisible) {
+                exoPlayer.seekForward()
+                pulseState.setType(FORWARD)
+            }
         },
         onUp = { videoPlayerState.showControls() },
         onDown = { videoPlayerState.showControls() },


### PR DESCRIPTION
Solves issue where, while moving focus around player controls resulted in SeekForward and SeekBackward events of player due to handleDPadKeyEvents modifier 