### PR TITLE
Fix #174: Selecting Seekbar to move video time freezes controls

### DIFF
--- a/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/videoPlayer/components/VideoPlayerIndicator.kt
+++ b/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/videoPlayer/components/VideoPlayerIndicator.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import com.google.jetstream.presentation.utils.handleDPadKeyEvents
+import com.google.jetstream.presentation.utils.ifElse
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalTvMaterial3Api::class)
 @Composable
@@ -70,35 +71,35 @@ fun RowScope.VideoPlayerControllerIndicator(
         }
     }
 
+    val handleSeekEventModifier = Modifier.handleDPadKeyEvents(
+        onEnter = {
+            isSelected = !isSelected
+            onSeek(seekProgress)
+        },
+        onLeft = {
+            seekProgress = (seekProgress - 0.1f).coerceAtLeast(0f)
+        },
+        onRight = {
+            seekProgress = (seekProgress + 0.1f).coerceAtMost(1f)
+        }
+    )
+
+    val handleDpadCenterClickModifier = Modifier.handleDPadKeyEvents(
+        onEnter = {
+            seekProgress = progress
+            isSelected = !isSelected
+        }
+    )
+
     Canvas(
         modifier = Modifier
             .weight(1f)
             .height(animatedIndicatorHeight)
             .padding(horizontal = 4.dp)
-            .handleDPadKeyEvents(
-                onEnter = {
-                    if (isSelected) {
-                        onSeek(seekProgress)
-                        focusManager.moveFocus(FocusDirection.Exit)
-                    } else {
-                        seekProgress = progress
-                    }
-                    isSelected = !isSelected
-                },
-                onLeft = {
-                    if (isSelected) {
-                        seekProgress = (seekProgress - 0.1f).coerceAtLeast(0f)
-                    } else {
-                        focusManager.moveFocus(FocusDirection.Left)
-                    }
-                },
-                onRight = {
-                    if (isSelected) {
-                        seekProgress = (seekProgress + 0.1f).coerceAtMost(1f)
-                    } else {
-                        focusManager.moveFocus(FocusDirection.Right)
-                    }
-                }
+            .ifElse(
+                condition = isSelected,
+                ifTrueModifier = handleSeekEventModifier,
+                ifFalseModifier = handleDpadCenterClickModifier
             )
             .focusable(interactionSource = interactionSource),
         onDraw = {

--- a/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/videoPlayer/components/VideoPlayerIndicator.kt
+++ b/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/videoPlayer/components/VideoPlayerIndicator.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.unit.dp
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import com.google.jetstream.presentation.utils.handleDPadKeyEvents
-import com.google.jetstream.presentation.utils.ifElse
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalTvMaterial3Api::class)
 @Composable
@@ -61,6 +60,7 @@ fun RowScope.VideoPlayerControllerIndicator(
         targetValue = 4.dp.times((if (isFocused) 2.5f else 1f))
     )
     var seekProgress by remember { mutableStateOf(0f) }
+    val focusManager = LocalFocusManager.current
 
     LaunchedEffect(isSelected) {
         if (isSelected) {
@@ -70,36 +70,37 @@ fun RowScope.VideoPlayerControllerIndicator(
         }
     }
 
-    val handleSeekEventModifier = Modifier.handleDPadKeyEvents(
-        onEnter = {
-            isSelected = !isSelected
-            onSeek(seekProgress)
-        },
-        onLeft = {
-            seekProgress = (seekProgress - 0.1f).coerceAtLeast(0f)
-        },
-        onRight = {
-            seekProgress = (seekProgress + 0.1f).coerceAtMost(1f)
-        }
-    )
-
-    val handleDpadCenterClickModifier = Modifier.handleDPadKeyEvents(
-        onEnter = {
-            seekProgress = progress
-            isSelected = !isSelected
-        }
-    )
-
     Canvas(
         modifier = Modifier
             .weight(1f)
             .height(animatedIndicatorHeight)
             .padding(horizontal = 4.dp)
-            .ifElse(
-                condition = isSelected,
-                ifTrueModifier = handleSeekEventModifier,
-                ifFalseModifier = handleDpadCenterClickModifier
-            ).focusable(interactionSource = interactionSource),
+            .handleDPadKeyEvents(
+                onEnter = {
+                    if (isSelected) {
+                        onSeek(seekProgress)
+                        focusManager.moveFocus(FocusDirection.Exit)
+                    } else {
+                        seekProgress = progress
+                    }
+                    isSelected = !isSelected
+                },
+                onLeft = {
+                    if (isSelected) {
+                        seekProgress = (seekProgress - 0.1f).coerceAtLeast(0f)
+                    } else {
+                        focusManager.moveFocus(FocusDirection.Left)
+                    }
+                },
+                onRight = {
+                    if (isSelected) {
+                        seekProgress = (seekProgress + 0.1f).coerceAtMost(1f)
+                    } else {
+                        focusManager.moveFocus(FocusDirection.Right)
+                    }
+                }
+            )
+            .focusable(interactionSource = interactionSource),
         onDraw = {
             val yOffset = size.height.div(2)
             drawLine(

--- a/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/utils/ModifierUtils.kt
+++ b/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/utils/ModifierUtils.kt
@@ -60,8 +60,7 @@ fun Modifier.handleDPadKeyEvents(
         }
 
         KeyEvent.KEYCODE_DPAD_CENTER, KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_NUMPAD_ENTER -> {
-            onEnter?.apply {
-                onActionUp(::invoke)
+            onEnter?.invoke().also {
                 return@onPreviewKeyEvent true
             }
         }

--- a/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/utils/ModifierUtils.kt
+++ b/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/utils/ModifierUtils.kt
@@ -60,7 +60,8 @@ fun Modifier.handleDPadKeyEvents(
         }
 
         KeyEvent.KEYCODE_DPAD_CENTER, KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_NUMPAD_ENTER -> {
-            onEnter?.invoke().also {
+            onEnter?.apply {
+                onActionUp(::invoke)
                 return@onPreviewKeyEvent true
             }
         }


### PR DESCRIPTION
- This PR solves the issue caused due to removal of  `onActionUp(::invoke)` from handleDPadKeyEvents Modifier extension fun.

- Also when we first move the focus from play/pause button to VideoPlayerIndicator the focus is moved to right side again because of this condition, when the VideoPlayerIndicator is not selected then it should not override the onLeft and onRight behaviour, focus events are handled properly when the onLeft and onRight is not overrided

```
    onRight = {
        if (isSelected) {
             seekProgress = (seekProgress + 0.1f).coerceAtMost(1f)
       } else {
            focusManager.moveFocus(FocusDirection.Right)
       }
    }
```
 
- Also removed the focusManager.moveFocus(FocusDirection.Exit) called on onSeek event, because the focus was lost from the screen, and came back only when play/pause button was focused again when overlay is visible again 