### PR TITLE
fix task compileBenchmarkReleaseKotlin

### DIFF
--- a/JetStreamCompose/benchmark/build.gradle.kts
+++ b/JetStreamCompose/benchmark/build.gradle.kts
@@ -63,6 +63,7 @@ baselineProfile {
 
 
 dependencies {
+    implementation(libs.androidx.compose.runtime.base)
     implementation(libs.androidx.junit)
     implementation(libs.androidx.uiautomator)
 

--- a/JetStreamCompose/gradle/libs.versions.toml
+++ b/JetStreamCompose/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidx-baselineprofile = "1.3.1"
 benchmark-macro-junit4 = "1.3.1"
 coil-compose = "2.6.0"
 compose-bom = "2024.09.02"
+compose-runtime = "1.7.6"
 tv-material = "1.0.0"
 core-ktx = "1.13.1"
 core-splashscreen = "1.0.1"
@@ -27,6 +28,7 @@ rules = "1.6.1"
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "benchmark-macro-junit4" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
+androidx-compose-runtime-base = { module = "androidx.compose.runtime:runtime", version.ref = "compose-runtime" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }

--- a/JetStreamCompose/jetstream/build.gradle.kts
+++ b/JetStreamCompose/jetstream/build.gradle.kts
@@ -68,6 +68,7 @@ android {
 }
 
 dependencies {
+    implementation(libs.androidx.compose.runtime.base)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)


### PR DESCRIPTION
Hello everyone,

I’m currently learning Kotlin and still quite new to it.
I’m working on Windows 11 with Android Studio (version Ladybug | 2024.2.1 Patch 3) and trying to compile the JetStreamCompose project. However, I encounter the following error in the task compileBenchmarkReleaseKotlin:
`The Compose Compiler requires the Compose Runtime to be on the class path, but none could be found. The compose compiler plugin you are using (version 1.5.14) expects a minimum runtime version of 1.0.0.`

When I add back the dependency androidx.compose.runtime:runtime, which was removed in Pull Request https://github.com/android/tv-samples/commit/40caf7dd72659f38ce59021ac6768adede16d58c, the project works fine again. However, I’m unsure if this is the correct approach.

Additionally, I noticed that the JetStreamCompose project does not appear as a sample in Android Studio, as described in [this article](https://developer.android.com/develop/ui/compose/setup#sample).
What could be the reason for this?