### PR TITLE
Remove TV prefix from Lazy* scrollable components after migration to common foundation

### DIFF
--- a/JetStreamCompose/README.md
+++ b/JetStreamCompose/README.md
@@ -24,11 +24,11 @@ real-world architecture.
 * Showcases
   * TabRow
   * Carousel
-  * TvLazyRow
+  * LazyRow
   * ImmersiveList
-  * TvLazyColumn
+  * LazyColumn
   * Tv Material Surface
-  * TvVerticalGrid
+  * VerticalGrid
   * Tv Material Cards
   * Buttons
   * Icon


### PR DESCRIPTION
This PR updates README to reflect of LazyRow, LazyColumn, and other Lazy* scrollable components by removing the TV-specific prefix. These components have been migrated to the common androidx.compose.foundation.lazy package, so this change aligns the codebase with the latest API structure.
