### PR TITLE
Refactor: enhance player architecture and fix background playback issue

### DIFF
--- a/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/videoPlayer/VideoPlayerManager.kt
+++ b/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/videoPlayer/VideoPlayerManager.kt
@@ -1,0 +1,56 @@
+package com.google.jetstream.presentation.screens.videoPlayer
+
+import android.content.Context
+import androidx.media3.common.C
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import com.google.jetstream.data.entities.MovieDetails
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+@UnstableApi
+// Do not make this a singleton to prevent Released player from Being invoked for play
+
+/**
+ * A manager for the video player.
+ * This class is responsible for managing the video playback using the ExoPlayer library.
+ *
+ * @param VideoPlayerManager  Creates an Instance of the player and it available across app for Re-use.
+ */
+class VideoPlayerManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private var _exoPlayer: ExoPlayer? = ExoPlayer.Builder(context)
+        .setSeekForwardIncrementMs(10)
+        .setSeekBackIncrementMs(10)
+        .setMediaSourceFactory(
+            ProgressiveMediaSource.Factory(DefaultDataSource.Factory(context))
+        )
+        .setVideoScalingMode(C.VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING)
+        .build().apply {
+            playWhenReady = true
+            repeatMode = Player.REPEAT_MODE_OFF
+        }
+
+    val player: ExoPlayer
+        get() = _exoPlayer ?: throw IllegalStateException("Player has been released")
+
+    fun load(movieDetails: MovieDetails) {
+        player.apply {
+            stop()
+            clearMediaItems()
+            addMediaItem(movieDetails.intoMediaItem())
+            movieDetails.similarMovies.forEach { addMediaItem(it.intoMediaItem()) }
+            prepare()
+        }
+    }
+
+    fun release() {
+        _exoPlayer?.release()
+        _exoPlayer = null
+    }
+}
+

--- a/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/videoPlayer/VideoPlayerScreenViewModel.kt
+++ b/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/videoPlayer/VideoPlayerScreenViewModel.kt
@@ -16,38 +16,65 @@
 
 package com.google.jetstream.presentation.screens.videoPlayer
 
+import androidx.annotation.OptIn
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
 import com.google.jetstream.data.entities.MovieDetails
 import com.google.jetstream.data.repositories.MovieRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
+@UnstableApi
 @HiltViewModel
-class VideoPlayerScreenViewModel @Inject constructor(
+@OptIn(UnstableApi::class)
+class VideoPlayerScreenViewModel
+@Inject constructor(
     savedStateHandle: SavedStateHandle,
-    repository: MovieRepository,
+    private val repository: MovieRepository,
+    private val playerManager: VideoPlayerManager
 ) : ViewModel() {
-    val uiState = savedStateHandle
-        .getStateFlow<String?>(VideoPlayerScreen.MovieIdBundleKey, null)
+
+    private val movieIdFlow = savedStateHandle.getStateFlow<String?>(
+        VideoPlayerScreen.MovieIdBundleKey,
+        null
+    )
+
+    val uiState: StateFlow<VideoPlayerScreenUiState> = movieIdFlow
         .map { id ->
             if (id == null) {
                 VideoPlayerScreenUiState.Error
             } else {
-                val details = repository.getMovieDetails(movieId = id)
-                VideoPlayerScreenUiState.Done(movieDetails = details)
+                try {
+                    val details = repository.getMovieDetails(id)
+                    playerManager.load(details)
+                    VideoPlayerScreenUiState.Done(details)
+                } catch (e: Exception) {
+                    VideoPlayerScreenUiState.Error
+                }
             }
-        }.stateIn(
+        }
+        .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = VideoPlayerScreenUiState.Loading
         )
+
+    val player: ExoPlayer get() = playerManager.player
+
+    override fun onCleared() {
+        super.onCleared()
+        playerManager.release()
+    }
 }
+
 
 @Immutable
 sealed class VideoPlayerScreenUiState {


### PR DESCRIPTION
Here is a list of Improvements this PR Tends to Fix.

- Scoped ExoPlayer to ViewModel to prevent reuse after release
- Removed singleton usage to avoid dead thread crashes
- Ensured ExoPlayer releases on screen exit via onCleared()
- Fixed bug where video continued playing after user left the app
- Improved separation of concerns via VideoPlayerManager abstraction

**Previous Behavior**
1. Initiating a new play, previous play continue and and they play concurrently.
2. When user Quits the Jetstream app, the video continues playing in background as Audio.
3. User is unable to tell where to stop it whenever it continues to play after app is quit.

**Expected behavior**
1. Player instance is one. One single play at a time. Initiating another play, disposes previous and begins another correctly.
2. Player releases whenever user quits app and does not continue playing in the background.

<img width="1043" alt="image" src="https://github.com/user-attachments/assets/50d5b23a-aa1c-4912-a070-628606cb0ad0" />

<img width="1043" alt="image" src="https://github.com/user-attachments/assets/36be9cec-b9e0-460a-9775-0031fd4ac4e9" />
