### PR TITLE
Fix: Topbar navigation recomposition

### DIFF
--- a/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/dashboard/DashboardScreen.kt
+++ b/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/dashboard/DashboardScreen.kt
@@ -181,8 +181,7 @@ fun DashboardScreen(
             selectedTabIndex = currentTopBarSelectedTabIndex,
         ) { screen ->
             val targetRoute = screen()
-            val currentRoute = navController.currentBackStackEntry?.destination?.route
-            if (currentRoute != targetRoute) {
+            if (currentDestination != targetRoute) {
                 navController.navigate(targetRoute) {
                     if (screen == TopBarTabs[0]) popUpTo(TopBarTabs[0].invoke())
                     launchSingleTop = true

--- a/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/dashboard/DashboardScreen.kt
+++ b/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/dashboard/DashboardScreen.kt
@@ -180,9 +180,13 @@ fun DashboardScreen(
                 ),
             selectedTabIndex = currentTopBarSelectedTabIndex,
         ) { screen ->
-            navController.navigate(screen()) {
-                if (screen == TopBarTabs[0]) popUpTo(TopBarTabs[0].invoke())
-                launchSingleTop = true
+            val targetRoute = screen()
+            val currentRoute = navController.currentBackStackEntry?.destination?.route
+            if (currentRoute != targetRoute) {
+                navController.navigate(targetRoute) {
+                    if (screen == TopBarTabs[0]) popUpTo(TopBarTabs[0].invoke())
+                    launchSingleTop = true
+                }
             }
         }
 


### PR DESCRIPTION
### Summary
This pull request fixes an issue where navigating to the same screen multiple times could occur when interacting with the TopBar. See: https://github.com/android/tv-samples/issues/210

### Problem
Currently, when a user focuses or clicks on a TopBar tab that corresponds to the screen they are already on, the app still triggers a navigation action.  
This behavior leads to an unnecessary recomposition of the current screen, causing redundant work and a less smooth user experience.

**Before (current behavior):**  

https://github.com/user-attachments/assets/1fa5e954-c7a8-474b-8506-11177ced51ca


- Selecting the same tab again triggers navigation.  
- The current screen is recomposed unnecessarily.  

**After (fixed behavior):**  

https://github.com/user-attachments/assets/0809af0c-f1ed-4eab-a2ae-b08d7d1b9a92  

- Selecting the same tab no longer triggers navigation.  
- The app remains stable on the current screen without recomposing.  

### Changes Introduced
- Added a validation in `DashboardScreen` to compare the current route with the target route before calling `navController.navigate()`.  
- Updated `DashboardTopBar` so that `onFocus` and `onClick` events only trigger navigation if the selected tab is different from the current one.  

### Benefits
- Prevents redundant navigation calls.  
- Avoids unnecessary recompositions.  
- Improves performance and ensures a smoother user experience when interacting with the TopBar. 
