### PR TITLE
Use jvmToolchain 21 for JetStream

### DIFF
--- a/JetStreamCompose/benchmark/build.gradle.kts
+++ b/JetStreamCompose/benchmark/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 android {

--- a/JetStreamCompose/jetstream/build.gradle.kts
+++ b/JetStreamCompose/jetstream/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 android {
@@ -67,7 +67,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "21"
     }
 }
 

--- a/JetStreamCompose/jetstream/build.gradle.kts
+++ b/JetStreamCompose/jetstream/build.gradle.kts
@@ -65,10 +65,6 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
-
-    kotlinOptions {
-        jvmTarget = "21"
-    }
 }
 
 dependencies {


### PR DESCRIPTION
Android Studio's built-in jbr is based on openjdk 21.0.8

Fix: android/tv-samples#192