### PR TITLE
chore: remove outdated TODO already implemented in VideoPlayerScreen

### DIFF
--- a/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/videoPlayer/VideoPlayerScreen.kt
+++ b/JetStreamCompose/jetstream/src/main/java/com/google/jetstream/presentation/screens/videoPlayer/VideoPlayerScreen.kt
@@ -72,7 +72,6 @@ fun VideoPlayerScreen(
 ) {
     val uiState by videoPlayerScreenViewModel.uiState.collectAsStateWithLifecycle()
 
-    // TODO: Handle Loading & Error states
     when (val s = uiState) {
         is VideoPlayerScreenUiState.Loading -> {
             Loading(modifier = Modifier.fillMaxSize())


### PR DESCRIPTION
## What
Remove the obsolete `// TODO: Handle Loading & Error states` comment in `VideoPlayerScreen`.

## Why
The `when (uiState)` block directly below the comment already handles all `VideoPlayerScreenUiState` cases — `Loading`, `Error`, and `Done`. 
The TODO was left behind after the states were implemented by #168  and is now misleading. 
Removing it keeps the code aligned with its actual behavior.


## Changes
- Removed the stale TODO comment in `VideoPlayerScreen.kt`.
  
No functional changes.
